### PR TITLE
feat: validate file type - allow only images

### DIFF
--- a/client/src/pages/add-post-page/AddPostPage.component.jsx
+++ b/client/src/pages/add-post-page/AddPostPage.component.jsx
@@ -50,6 +50,8 @@ const AddPostPage = ({ addPost, history }) => {
     post.append("repoUrl", repoUrl);
     setIsSubmitting(true);
     addPost(post, history);
+    //allow re-submitting the form after fixing validation errors
+    setIsSubmitting(false);
   };
 
   return (

--- a/middleware/cloudinary.js
+++ b/middleware/cloudinary.js
@@ -1,6 +1,7 @@
 const config = require("config");
 const multer = require("multer");
 const cloudinary = require("cloudinary").v2;
+const path = require("path")
 const { CloudinaryStorage } = require("multer-storage-cloudinary");
 
 cloudinary.config({
@@ -16,6 +17,17 @@ const storage = new CloudinaryStorage({
   },
 });
 
-const upload = multer({ storage }).array("postImage", 5);
+const upload = multer({ 
+    storage,
+    fileFilter: function (req, file, callback) {
+      var ext = path.extname(file.originalname);
+      var errMsg;
+      if(ext !== '.png' && ext !== '.jpg' && ext !== '.gif' && ext !== '.jpeg') {
+        errMsg = 'Only images are allowed'
+        req.fileValidationError = errMsg;
+        return callback(null, false, new Error(errMsg));
+      }
+      callback(null, true)
+    }}).array("postImage", 5);
 
 module.exports = upload;

--- a/routes/api/posts.js
+++ b/routes/api/posts.js
@@ -24,6 +24,7 @@ router.post(
   async (req, res) => {
     // Check for validation errors
     const errors = validationResult(req);
+    if(req.fileValidationError) errors.errors.push({msg:req.fileValidationError});
     if (!errors.isEmpty()) {
       return res.status(400).json({ errors: errors.array() });
     }


### PR DESCRIPTION
1. Added a filter to multer that only allows .png, .jpg, .gif and .jpeg extensions
2. Pass a file upload error to the client if the file type is not one of the list above
3. call setIsSubmitting(false) after addPost to allow resubmitting the form if server validation found errors.

Issue #2